### PR TITLE
Add flagfile support

### DIFF
--- a/example_flagfile
+++ b/example_flagfile
@@ -1,0 +1,17 @@
+--loop-count 5  # a comment here
+# and a comment there
+--verbose
+
+#### Notes:
+
+# one flag and value per line at most
+# blank lines and comment lines are also allowed
+
+# --flag "quoted values # with hashes work, too" note that comments
+# can be directly adjacent to flags like:
+#    "--verbose#set verbose mode to true"
+# but this is due to a bug in Python's shlex module.
+
+# flagfiles can include other flagfiles, and even have cycles
+# cycles are no issue because flagfiles are stateless
+--flagfile example_flagfile

--- a/face/command.py
+++ b/face/command.py
@@ -64,13 +64,13 @@ DEFAULT_HELP_HANDLER = HelpHandler()
 # initialized in one call.
 class Command(Parser):
     def __init__(self, func, name=None, doc=None, posargs=False, middlewares=None,
-                 print_error=None, help=DEFAULT_HELP_HANDLER):
+                 print_error=None, help=DEFAULT_HELP_HANDLER, flagfile=True):
         name = name if name is not None else _get_default_name()
 
         if doc is None:
             doc = _docstring_to_doc(func)
 
-        super(Command, self).__init__(name, doc, posargs=posargs)
+        super(Command, self).__init__(name, doc, posargs=posargs, flagfile=flagfile)
         # TODO: properties for name/doc/other parser things
 
         self._path_func_map = OrderedDict()

--- a/face/command.py
+++ b/face/command.py
@@ -156,6 +156,9 @@ class Command(Parser):
         flag_map = super(Command, self).get_flag_map(path=path, with_hidden=with_hidden)
         dep_names = self.get_dep_names(path)
 
+        # TODO: if dep_names includes args_ or flags_ we need to
+        # bypass the default filtering and either let all flags
+        # through or just the ones declared by some decorator.
         return dict([(k, f) for k, f in flag_map.items() if f.name in dep_names
                      or f is self.flagfile_flag or f is self.help_handler.flag])
 

--- a/face/command.py
+++ b/face/command.py
@@ -16,7 +16,9 @@ from face.middleware import (inject,
 from boltons.iterutils import unique
 
 class CommandLineError(FaceException, SystemExit):
-    pass
+    def __init__(self, msg, code=1):
+        SystemExit.__init__(self, msg)
+        self.code = code
 
 
 def _get_default_name(frame_level=1):

--- a/face/parser.py
+++ b/face/parser.py
@@ -498,7 +498,7 @@ class Parser(object):
     """
     Parser parses, Command parses with Parser, then dispatches.
     """
-    def __init__(self, name, doc=None, posargs=None):
+    def __init__(self, name, doc=None, posargs=None, flagfile=True):
         if not name or name[0] in ('-', '_'):
             # TODO: more complete validation
             raise ValueError('expected name beginning with ASCII letter, not: %r' % (name,))
@@ -516,7 +516,15 @@ class Parser(object):
                              ' or instance of PosArgSpec, not: %r' % posargs)
         self.posargs = posargs
 
-        self.flagfile_flag = FLAGFILE_ENABLED
+        if flagfile is True:
+            self.flagfile_flag = FLAGFILE_ENABLED
+        elif isinstance(flagfile, Flag):
+            self.flagfile_flag = flagfile
+        elif not flagfile:
+            self.flagfile_flag = None
+        else:
+            raise ValueError('expected True, False, or Flag instance for'
+                             ' flagfile, not: %r' % flagfile)
 
         self.subprs_map = OrderedDict()
         self._path_flag_map = OrderedDict()


### PR DESCRIPTION
Many applications are small and simple enough that they can be more-or-less fully configured through flags, as long as those flags stay manageable. Flagfiles are a key feature to scaling command-line configurability, as they allow:

* Passing more flags than would comfortably fit on one line
* Commenting on flags and documenting values
* Creating and tracking (in source control) collections of flags that work well together (as one would do in a dev/stage/production or nightly/weekly/monthly situation)

This PR adds native flagfile support to face, with tooling that far exceeds other flagfile implementations (particularly in Python), including line number and file path specifics in error messages. One notable issue with the implementation is the reliance on the shlex builtin module, which has issues and could really use a rewrite.