### PR TITLE
Add command description wrapping.

### DIFF
--- a/face/helpers.py
+++ b/face/helpers.py
@@ -9,6 +9,7 @@ from boltons.iterutils import unique
 from face.parser import Flag, format_flag_label, format_flag_post_doc, format_posargs_label
 
 DEFAULT_HELP_FLAG = Flag('--help', parse_as=True, char='-h', doc='show this help message and exit')
+DEFAULT_MAX_WIDTH = 120
 
 
 def _get_termios_winsize():
@@ -47,6 +48,16 @@ def get_winsize():
     return rows, cols
 
 
+def get_doc_width(width=None, max_width=DEFAULT_MAX_WIDTH):
+    if width is None:
+        _, width = get_winsize()
+        if width is None:
+            width = 80
+        width = min(width, max_width)
+        width -= 2
+    return width
+
+
 def _wrap_stout_pair(indent, label, sep, doc, doc_start, max_doc_width):
     # TODO: consider making the fill character configurable (ljust
     # uses space by default, the just() methods can only take
@@ -75,13 +86,17 @@ def _wrap_stout_pair(indent, label, sep, doc, doc_start, max_doc_width):
     return ret
 
 
-def get_stout_layout(labels, indent, sep, width=None, max_width=120, min_doc_width=40):
-    if width is None:
-        _, width = get_winsize()
-        if width is None:
-            width = 80
-        width = min(width, max_width)
-        width -= 2
+def _wrap_stout_cmd_doc(indent, doc, max_width):
+    """Function for wrapping command description."""
+    return textwrap.fill(text=doc,
+                         width=(max_width - len(indent)),
+                         initial_indent=indent,
+                         subsequent_indent=indent)
+
+
+def get_stout_layout(labels, indent, sep, width=None, max_width=DEFAULT_MAX_WIDTH,
+                     min_doc_width=40):
+    width = get_doc_width(width=width, max_width=max_width)
 
     len_sep = len(sep)
     len_indent = len(indent)
@@ -233,7 +248,11 @@ class StoutHelpFormatter(object):
             parser = parser.subprs_map[subcmds]
 
         if parser.doc:
-            append(parser.doc)
+            append(_wrap_stout_cmd_doc(indent=ctx['section_indent'],
+                                       doc=parser.doc,
+                                       max_width=get_doc_width(
+                                           width=ctx['width'],
+                                           max_width=ctx['max_width'])))
             append(ctx['section_break'])
 
         if parser.subprs_map:


### PR DESCRIPTION
This provides wrapping for the command description that is pulled from the doc string of the function that backs the command. This functionality is provided by `_wrap_stout_cmd_doc()`.

Also creates `get_doc_width()` function and `DEFAULT_MAX_WIDTH` variable.
The code in `get_doc_width()` was extracted from `get_stout_layout()`, to avoid duplication.

## Example

A function with a doc sting of about 140 characters used to create a command.

```python
def busy_loop(loop_count):
    """
    Does a bit of busy work. No sweat. Does a bit of busy work. No sweat. Does a bit of busy work. No sweat. Does a bit of busy work. No sweat.
    """
    for i in range(loop_count or 3):
        print('work %s\n' % (i + 1))
    return

cmd = Command(busy_loop, 'cmd')
cmd.run(argv=['example.py', '--help'])
```

A ~50 character wide terminal displays the following:
```
Usage: example.py [FLAGS]

  Does a bit of busy work. No sweat. Does a bit
  of busy work. No sweat. Does a bit of busy
  work. No sweat. Does a bit of busy work. No
  sweat.


Flags:

  --help / -h
   show this help message and exit

An exception has occurred, use %tb to see the full traceback.
```

80 Character

```
Usage: example.py [FLAGS]

  Does a bit of busy work. No sweat. Does a bit of busy work. No sweat. Does a
  bit of busy work. No sweat. Does a bit of busy work. No sweat.


Flags:

  --help / -h   show this help message and exit

An exception has occurred, use %tb to see the full traceback.
```

---

@mahmoud  Once I've improved the test for this I will submit it in a separate pull request, so we can discuss/work on it separately. I figure it will require more back and forth so I can better understand your approach to testing and how you want it in this project.

Also, going to wait on feedback for #2 and #3 before I finalize the tests.

Let me know if this works for you.