### PR TITLE
Add subcommand grouping via CommandGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ _(Not yet released)_
 - Add Codecov integration
 - Drop Python 3.8 and 3.9 support (now requires >=3.10)
 - Add CHANGELOG.md
+- Add subcommand grouping via `CommandGroup` class and `group` parameter

--- a/docs/command.rst
+++ b/docs/command.rst
@@ -169,6 +169,49 @@ You can also add a pre-built :class:`~face.Command` instance:
 Subcommands nest arbitrarily. A subcommand is itself a Command, so it
 can have its own subcommands, flags, and middleware.
 
+Subcommand groups
+~~~~~~~~~~~~~~~~~
+
+For commands with many subcommands, organize them under named headings
+in help output using :class:`~face.CommandGroup`:
+
+.. code-block:: python
+
+    from face import Command, CommandGroup
+
+    cmd = Command(None, name='myapp')
+
+    # Ungrouped subcommands appear first in help
+    cmd.add(version)
+
+    # Grouped subcommands appear under headings
+    users = CommandGroup('Users')
+    users.add(create_user)
+    users.add(delete_user)
+    cmd.add(users)
+
+    admin = CommandGroup('Admin')
+    admin.add(list_logs)
+    cmd.add(admin)
+
+This produces help output like::
+
+    Subcommands:
+
+      version        show the version
+
+      Users:
+        create-user    create a new user
+        delete-user    remove a user
+
+      Admin:
+        list-logs      display application logs
+
+A ``group`` keyword argument can also be passed directly to
+:meth:`~face.Command.add` for convenience::
+
+    cmd.add(create_user, group='Users')
+
 Positional arguments
 --------------------
 

--- a/face/__init__.py
+++ b/face/__init__.py
@@ -18,7 +18,7 @@ from face.errors import (FaceException,
                          UsageError)
 
 from face.parser import (ListParam, ChoicesParam)
-from face.command import Command
+from face.command import Command, CommandGroup
 from face.middleware import face_middleware
 from face.helpers import HelpHandler, StoutHelpFormatter
 from face.testing import CommandChecker, CheckError

--- a/face/command.py
+++ b/face/command.py
@@ -52,6 +52,48 @@ def default_print_error(msg):
 DEFAULT_HELP_HANDLER = HelpHandler()
 
 
+class CommandGroup:
+    """A named group of subcommands that are added flat to a parent Command.
+
+    When added to a Command via ``cmd.add(group)``, all of the group's
+    subcommands become direct subcommands of the parent, tagged with the
+    group name for organized help display. No new subcommand path level
+    is created.
+
+    Args:
+       name: The group heading displayed in help output.
+       doc: An optional description (reserved for future use).
+    """
+    def __init__(self, name, doc=None):
+        if not isinstance(name, str) or not name:
+            raise ValueError(f'expected non-empty string for CommandGroup name, not: {name!r}')
+        self.name = name
+        self.doc = doc
+        self._commands = []
+
+    def add(self, *a, **kw):
+        """Add a subcommand to this group. Accepts the same arguments as
+        Command() for subcommand construction: a callable (or None) as the
+        first argument, plus optional name, doc, flags, posargs, etc.
+
+        Also accepts a pre-built Command instance directly.
+
+        Returns the Command instance.
+        """
+        target = a[0]
+        if isinstance(target, Command):
+            subcmd = target
+        elif callable(target) or target is None:
+            subcmd = Command(*a, **kw)
+        else:
+            raise TypeError(f'expected callable or Command for CommandGroup.add(), not: {target!r}')
+        self._commands.append(subcmd)
+        return subcmd
+
+    def __repr__(self):
+        return f'CommandGroup({self.name!r}, commands={len(self._commands)})'
+
+
 # TODO: should name really go here?
 class Command(Parser):
     """The central type in the face framework. Instantiate a Command,
@@ -80,6 +122,9 @@ class Command(Parser):
            instance.
         middlewares: A list of @face_middleware decorated
            callables which participate in dispatch.
+        group: An optional string group name for display
+           in help output. See CommandGroup for the recommended way
+           to group multiple subcommands.
     """
     def __init__(self, 
                  func: Optional[Callable],
@@ -91,7 +136,8 @@ class Command(Parser):
                  post_posargs: Optional[bool] = None,
                  flagfile: bool = True,
                  help: Union[bool, HelpHandler] = DEFAULT_HELP_HANDLER,
-                 middlewares: Optional[List[Callable]] = None) -> None:
+                 middlewares: Optional[List[Callable]] = None,
+                 group: Optional[str] = None) -> None:
         name = name if name is not None else _get_default_name(func)
         if doc is None:
             doc = _docstring_to_doc(func)
@@ -101,7 +147,8 @@ class Command(Parser):
                         flags=flags,
                         posargs=posargs,
                         post_posargs=post_posargs,
-                        flagfile=flagfile)
+                        flagfile=flagfile,
+                        group=group)
 
         self.help_handler = help
 
@@ -162,6 +209,9 @@ class Command(Parser):
 
         target = a[0]
 
+        if isinstance(target, CommandGroup):
+            return self.add_command_group(target)
+
         if is_middleware(target):
             return self.add_middleware(target)
 
@@ -198,6 +248,20 @@ class Command(Parser):
                 self._path_func_map[path] = subcmd._path_func_map[path[1:]]
                 sub_mw = subcmd._path_mw_map[path[1:]]
                 self._path_mw_map[path] = self_mw + sub_mw  # TODO: check for conflicts
+        return
+
+    def add_command_group(self, group):
+        """Add all commands from a CommandGroup as direct subcommands of this
+        Command, tagged with the group's name for organized help display.
+
+        No new subcommand path level is created — the group's commands
+        become siblings of any existing subcommands.
+        """
+        if not isinstance(group, CommandGroup):
+            raise TypeError(f'expected CommandGroup instance, not: {group!r}')
+        for subcmd in group._commands:
+            subcmd.group = group.name
+            self.add_command(subcmd)
         return
 
     def add_middleware(self, mw):

--- a/face/helpers.py
+++ b/face/helpers.py
@@ -146,6 +146,29 @@ DEFAULT_CONTEXT = {
 }
 
 
+def _get_subcmd_groups(parser):
+    """Return a dict mapping group key -> list of (sub_name, subprs).
+
+    Group key is a string (named group), int (unnamed visual break),
+    or None (ungrouped). Insertion order preserved: first occurrence
+    of a group determines its position. None-group (ungrouped) is
+    always sorted first regardless of insertion order.
+    """
+    groups = {}
+    for sub_name in unique([sp[0] for sp in parser.subprs_map if sp]):
+        subprs = parser.subprs_map[(sub_name,)]
+        group = subprs.group
+        groups.setdefault(group, []).append((sub_name, subprs))
+
+    # Move ungrouped (None) to front
+    if None in groups:
+        ungrouped = groups.pop(None)
+        result = {None: ungrouped}
+        result.update(groups)
+        return result
+    return groups
+
+
 class StoutHelpFormatter:
     """This formatter takes :class:`Parser` and :class:`Command` instances
     and generates help text. The output style is inspired by, but not
@@ -261,21 +284,50 @@ class StoutHelpFormatter:
             append(ctx['section_break'])
 
         if parser.subprs_map:
-            subcmd_names = unique([sp[0] for sp in parser.subprs_map if sp])
-            subcmd_layout = self._get_layout(labels=subcmd_names)
+            subcmd_groups = _get_subcmd_groups(parser)
+            has_named_groups = any(isinstance(g, str) for g in subcmd_groups)
+
+            # Compute layout across ALL subcommands for consistent doc-column alignment.
+            all_subcmd_names = [n.replace('_', '-') for n in
+                                unique([sp[0] for sp in parser.subprs_map if sp])]
+            if has_named_groups:
+                subcmd_layout = get_stout_layout(
+                    labels=all_subcmd_names,
+                    indent=ctx['section_indent'] * 2,
+                    sep=ctx['doc_separator'],
+                    width=ctx['width'],
+                    max_width=ctx['max_width'],
+                    min_doc_width=ctx['min_doc_width'])
+            else:
+                subcmd_layout = self._get_layout(labels=all_subcmd_names)
 
             append(ctx['subcmd_section_heading'])
             append(ctx['group_break'])
-            for sub_name in unique([sp[0] for sp in parser.subprs_map if sp]):
-                subprs = parser.subprs_map[(sub_name,)]
-                # TODO: sub_name.replace('_', '-') = _cmd -> -cmd (need to skip replacing leading underscores)
-                subcmd_lines = _wrap_stout_pair(indent=ctx['section_indent'],
-                                                label=sub_name.replace('_', '-'),
-                                                sep=ctx['doc_separator'],
-                                                doc=subprs.doc,
-                                                doc_start=subcmd_layout['doc_start'],
-                                                max_doc_width=subcmd_layout['doc_width'])
-                ret.extend(subcmd_lines)
+
+            first_group = True
+            for group_key, group_subcmds in subcmd_groups.items():
+                if not first_group:
+                    append('')  # blank line between groups
+                first_group = False
+
+                if isinstance(group_key, str):
+                    append(ctx['section_indent'] + group_key + ':')
+
+                # Ungrouped items use section_indent; grouped items use double indent
+                if has_named_groups and isinstance(group_key, str):
+                    item_indent = ctx['section_indent'] * 2
+                else:
+                    item_indent = ctx['section_indent']
+
+                for sub_name, subprs in group_subcmds:
+                    subcmd_lines = _wrap_stout_pair(
+                        indent=item_indent,
+                        label=sub_name.replace('_', '-'),
+                        sep=ctx['doc_separator'],
+                        doc=subprs.doc,
+                        doc_start=subcmd_layout['doc_start'],
+                        max_doc_width=subcmd_layout['doc_width'])
+                    ret.extend(subcmd_lines)
 
             append(ctx['section_break'])
 

--- a/face/parser.py
+++ b/face/parser.py
@@ -560,9 +560,10 @@ class Parser:
     :meth:`Parser.parse()` with ``sys.argv`` or any other list of strings.
     """
     def __init__(self, name, doc=None, flags=None, posargs=None,
-                 post_posargs=None, flagfile=True):
+                 post_posargs=None, flagfile=True, group=None):
         self.name = process_command_name(name)
         self.doc = doc
+        self.group = group
         flags = list(flags or [])
 
         self.posargs = _ensure_posargspec(posargs, 'posargs')

--- a/face/test/test_help.py
+++ b/face/test/test_help.py
@@ -248,3 +248,30 @@ def test_command_group_constructor():
     grp = CommandGroup('Valid')
     assert grp.name == 'Valid'
     assert grp._commands == []
+
+
+def test_command_group_add_prebuilt():
+    grp = CommandGroup('Ops')
+    subcmd = Command(lambda: None, name='deploy', doc='deploy it')
+    ret = grp.add(subcmd)
+    assert ret is subcmd
+    assert grp._commands == [subcmd]
+
+
+def test_command_group_add_invalid():
+    grp = CommandGroup('Ops')
+    with pytest.raises(TypeError, match='expected callable or Command'):
+        grp.add(42)
+
+
+def test_command_group_repr():
+    grp = CommandGroup('Ops')
+    assert repr(grp) == "CommandGroup('Ops', commands=0)"
+    grp.add(lambda: None, name='x')
+    assert repr(grp) == "CommandGroup('Ops', commands=1)"
+
+
+def test_add_command_group_invalid():
+    cmd = Command(None, name='app')
+    with pytest.raises(TypeError, match='expected CommandGroup instance'):
+        cmd.add_command_group('not a group')

--- a/face/test/test_help.py
+++ b/face/test/test_help.py
@@ -3,6 +3,7 @@ import pytest
 from face import (Flag,
                   ERROR,
                   Command,
+                  CommandGroup,
                   CommandChecker,
                   Parser,
                   PosArgSpec,
@@ -160,3 +161,90 @@ def test_missing_subcmd_checker():
     # Explicit help -> exit 0
     res = cc.run('halp subcmd -h')
     assert 'Usage' in res.stdout
+
+
+def test_subcmd_group_named():
+    cmd = Command(None, name='app')
+    setup = CommandGroup('Setup')
+    setup.add(lambda: None, name='create', doc='create a thing')
+    setup.add(lambda: None, name='delete', doc='delete a thing')
+    cmd.add(setup)
+    info = CommandGroup('Info')
+    info.add(lambda: None, name='list', doc='list things')
+    cmd.add(info)
+
+    cc = CommandChecker(cmd)
+    res = cc.run('app -h')
+    assert 'Setup:' in res.stdout
+    assert 'Info:' in res.stdout
+    assert 'create' in res.stdout
+    assert 'delete' in res.stdout
+    assert 'list' in res.stdout
+
+
+def test_subcmd_group_ungrouped_first():
+    cmd = Command(None, name='app')
+    cmd.add(lambda: None, name='version', doc='show version')
+    grp = CommandGroup('Ops')
+    grp.add(lambda: None, name='deploy', doc='deploy it')
+    cmd.add(grp)
+
+    cc = CommandChecker(cmd)
+    res = cc.run('app -h')
+    # version appears before 'Ops:' heading
+    vi = res.stdout.index('version')
+    oi = res.stdout.index('Ops:')
+    assert vi < oi
+
+
+def test_subcmd_group_backward_compat():
+    """Command with no groups produces same flat help output."""
+    cmd = Command(None, name='app')
+    cmd.add(lambda: None, name='alpha', doc='do alpha')
+    cmd.add(lambda: None, name='beta', doc='do beta')
+
+    cc = CommandChecker(cmd)
+    res = cc.run('app -h')
+    lines = res.stdout.splitlines()
+    # No group headings anywhere
+    assert not any(line.strip().endswith(':') and line.strip() != 'Subcommands:'
+                   and line.strip() != 'Flags:' for line in lines)
+    # Subcommands at normal indent, not double-indented
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped.startswith('alpha') or stripped.startswith('beta'):
+            indent = len(line) - len(stripped)
+            assert indent == 2  # section_indent is '  '
+
+
+def test_subcmd_group_kwarg():
+    cmd = Command(None, name='app')
+    cmd.add(lambda: None, name='foo', doc='do foo', group='Stuff')
+    cmd.add(lambda: None, name='bar', doc='do bar', group='Stuff')
+
+    cc = CommandChecker(cmd)
+    res = cc.run('app -h')
+    assert 'Stuff:' in res.stdout
+    assert 'foo' in res.stdout
+    assert 'bar' in res.stdout
+
+
+def test_subcmd_group_dispatch():
+    result = []
+    cmd = Command(None, name='app')
+    grp = CommandGroup('Ops')
+    grp.add(lambda: result.append('ran'), name='do_it')
+    cmd.add(grp)
+
+    cmd.run(['app', 'do-it'])
+    assert result == ['ran']
+
+
+def test_command_group_constructor():
+    with pytest.raises(ValueError):
+        CommandGroup('')
+    with pytest.raises(ValueError):
+        CommandGroup(None)
+    grp = CommandGroup('Valid')
+    assert grp.name == 'Valid'
+    assert grp._commands == []


### PR DESCRIPTION
## Summary

Add a `CommandGroup` class and `group` parameter for organizing subcommands under named headings in help output. This implements the planned feature from `DESIGN.md` (line 126) and the approach sketched in `helpers.py` (line 474).

### API

**`CommandGroup` class** — lightweight container for grouping subcommands:

```python
from face import Command, CommandGroup

cmd = Command(None, name='myapp')
cmd.add(version)  # ungrouped — appears first

users = CommandGroup('Users')
users.add(create_user)
users.add(delete_user)
cmd.add(users)  # adds flat, not nested
```

**`group` keyword** — inline alternative:

```python
cmd.add(create_user, group='Users')
```

### Help output

```
Subcommands:

  version        show the version

  Users:
    create-user    create a new user
    delete-user    remove a user
```

### Behavior

- Ungrouped commands (`group=None`) always render first, above all named groups
- Named groups appear in insertion order with items at double indent
- Doc columns are globally aligned across all subcommands
- **Fully backward compatible**: commands with no groups produce identical output to before

### Changes

- **`face/parser.py`**: Add `group=None` parameter to `Parser.__init__`
- **`face/command.py`**: New `CommandGroup` class; `Command.add()` detects and flattens groups via `add_command_group()`; `group` kwarg on `Command.__init__`
- **`face/helpers.py`**: New `_get_subcmd_groups()` helper; grouped rendering in `get_help_text()`
- **`face/__init__.py`**: Export `CommandGroup`
- **`face/test/test_help.py`**: 6 new tests (named groups, ungrouped-first ordering, backward compat, group kwarg, dispatch, constructor validation)
- **`docs/command.rst`**: New "Subcommand groups" documentation section
- **`CHANGELOG.md`**: Entry under 26.0.1