### PR TITLE
Fix inverted min_count/max_count error message

### DIFF
--- a/face/parser.py
+++ b/face/parser.py
@@ -412,7 +412,7 @@ class PosArgSpec:
         if self.max_count is not None and self.max_count <= 0:
             raise ValueError(f'expected max_count > 0, not: {self.max_count!r}')
         if self.max_count and self.min_count > self.max_count:
-            raise ValueError('expected min_count > max_count, not: %r > %r'
+            raise ValueError('expected min_count <= max_count, not: %r > %r'
                              % (self.min_count, self.max_count))
 
         provides = name if provides is None else provides

--- a/face/test/test_basic.py
+++ b/face/test/test_basic.py
@@ -207,7 +207,7 @@ def test_posargspec_init():
     with pytest.raises(ValueError, match='expected max_count > 0'):
         PosArgSpec(max_count=-1)
 
-    with pytest.raises(ValueError, match='expected min_count > max_count'):
+    with pytest.raises(ValueError, match='expected min_count <= max_count'):
         PosArgSpec(max_count=3, min_count=4)
 
     with pytest.raises(TypeError, match='.*PosArgDisplay instance.*'):


### PR DESCRIPTION
`PosArgSpec` raises when `min_count > max_count`, but the error message states that rejected condition as the *expectation*:

```python
>>> PosArgSpec(max_count=3, min_count=4)
ValueError: expected min_count > max_count, not: 4 > 3
```

It says it expected `min_count > max_count` — which is exactly what it just refused.

The two sibling checks immediately above state the condition that *should* hold:

```python
raise ValueError(f'expected min_count >= 0, not: {self.min_count!r}')
raise ValueError(f'expected max_count > 0, not: {self.max_count!r}')
```

So this one should read `<=`. After the change:

```
ValueError: expected min_count <= max_count, not: 4 > 3
```

Updated the matching assertion in `face/test/test_basic.py`, which pinned the old wording. Full suite passes locally (71 passed, 1 skipped).
