### PR TITLE
Keep help usable when descriptions contain only whitespace

### DIFF
--- a/face/helpers.py
+++ b/face/helpers.py
@@ -66,12 +66,12 @@ def _wrap_stout_pair(indent, label, sep, doc, doc_start, max_doc_width):
     append = ret.append
     lhs = indent + label
 
-    if not doc:
+    wrapped_doc = textwrap.wrap(doc, max_doc_width) if doc else []
+    if not wrapped_doc:
         append(lhs)
         return ret
 
     len_sep = len(sep)
-    wrapped_doc = textwrap.wrap(doc, max_doc_width)
     if len(lhs) <= doc_start:
         lhs_f = lhs.ljust(doc_start - len(sep)) + sep
         append(lhs_f + wrapped_doc[0])

--- a/face/test/test_help.py
+++ b/face/test/test_help.py
@@ -275,3 +275,27 @@ def test_add_command_group_invalid():
     cmd = Command(None, name='app')
     with pytest.raises(TypeError, match='expected CommandGroup instance'):
         cmd.add_command_group('not a group')
+
+
+@pytest.mark.parametrize('doc', ['', ' ', '\t', '\n', ' \n\t '])
+def test_help_with_blank_flag_documentation(doc):
+    cmd = Command(lambda blank: None, name='app')
+    cmd.add(Flag('blank', display={'full_doc': doc}))
+
+    result = CommandChecker(cmd).run('app --help')
+
+    assert result.exit_code == 0
+    assert '--blank' in result.stdout
+    assert not result.stderr
+
+
+@pytest.mark.parametrize('doc', ['', ' ', '\t', '\n', ' \n\t '])
+def test_help_with_blank_subcommand_documentation(doc):
+    cmd = Command(None, name='app')
+    cmd.add(lambda: None, name='blank', doc=doc)
+
+    result = CommandChecker(cmd).run('app --help')
+
+    assert result.exit_code == 0
+    assert 'blank' in result.stdout
+    assert not result.stderr


### PR DESCRIPTION
A whitespace-only flag description or subcommand description currently makes `--help` fail with `IndexError`: `textwrap.wrap()` returns no lines, but `_wrap_stout_pair()` indexes its first element. This also affects an explicitly supplied whitespace-only `FlagDisplay.full_doc`.

Check the wrapped lines before formatting the documentation column, so descriptions without printable text behave like empty descriptions and still show their flag or subcommand labels.

Validation:
- Added ten public `CommandChecker(...).run('app --help')` regression cases covering empty text, spaces, tabs, newlines, and mixed whitespace for both flags and subcommands. Eight fail before the fix; all ten pass afterward.
- Full suite: 84 passed on Python 3.12.
- Manually invoked a command's help with both blank descriptions, then dispatched its subcommand successfully.

AI disclosure: This patch and its tests were prepared with OpenAI Codex assistance. The before/after failures, full suite, and actual command invocation were executed locally.
